### PR TITLE
refactor(github-profile-finder): remove initial data fetch on mount

### DIFF
--- a/src/components/github-profile-finder/index.jsx
+++ b/src/components/github-profile-finder/index.jsx
@@ -23,9 +23,9 @@ export default function GithubProfileFinder() {
     fetchGithubUserData()
   }
 
-  useEffect(() => {
-    fetchGithubUserData();
-  }, []);
+//   useEffect(() => {
+//     fetchGithubUserData();
+//   }, []);
 
   if (loading) {
     return <h1>Loading data ! Please wait</h1>;


### PR DESCRIPTION
The initial data fetch was causing unnecessary API calls when the component mounts. Data fetching is now only triggered by user input.